### PR TITLE
capistrano 3.4.0の変更に追随

### DIFF
--- a/lib/capistrano/strategy/rsync.rb
+++ b/lib/capistrano/strategy/rsync.rb
@@ -79,6 +79,8 @@ namespace :rsync do
     next if !fetch(:rsync_cache)
 
     copy = %(#{fetch(:rsync_copy)} "#{rsync_cache.call}/" "#{release_path}/")
-    on roles(:all).each do execute copy end
+    on roles(:all) do |host|
+      execute copy
+    end
   end
 end


### PR DESCRIPTION
[capistrano 3.4.0の変更](https://github.com/capistrano/capistrano/commit/837eaca8b1585c414ddc0718a55fe0f592b3c79a)でBreaking Changesがあったようでそれへの対応です。
本家は相変わらず[issue](https://github.com/moll/capistrano-rsync/issues/23)だけですがforkされたリポジトリでは今回の変更が取り込まれているようです(今回の変更は下記の修正を参考にしています)。
- https://github.com/forumone/web-starter/issues/59 
- https://github.com/Bladrak/capistrano-rsync/pull/2

一応capistrano 3.4.0で問題なく動作することを確認しています(対応前だとエラー)
